### PR TITLE
TrustZone/QSEE exploitation plan

### DIFF
--- a/docs/plans/2026-03-08-trustzone-exploitation-plan.md
+++ b/docs/plans/2026-03-08-trustzone-exploitation-plan.md
@@ -112,22 +112,45 @@ for i in $(seq 1 30); do
 done 2>&1 | tee /data/local/tmp/drm_transactions.txt
 ```
 
-Key DRM transactions to identify:
-- `openDecryptSession` — opens a DRM session (path to plugin loading)
-- `initializeDecryptUnit` — initializes crypto (touches OEMCrypto)
-- `decrypt` — actual decryption (reaches QSEE)
-- `getConstraints` / `getDrmInfo` — metadata queries
+**Confirmed DRM transaction codes** (from AOSP IDrmManagerService for Android 6.0.1):
 
-**What we're looking for:** Which transaction codes reach the Widevine plugin and trigger QSEE operations. We'll confirm by watching dmesg during each call:
+| Code | Method | Reaches QSEE? |
+|------|--------|---------------|
+| 1 | ADD_UNIQUEID | No |
+| 3 | ADD_CLIENT | No (session setup) |
+| 11 | ACQUIRE_DRM_INFO | Yes (Widevine provisioning/license) |
+| 25 | OPEN_DECRYPT_SESSION | **Yes** (loads Widevine plugin, triggers QSEE) |
+| 26 | OPEN_DECRYPT_SESSION_FROM_URI | **Yes** |
+| 28 | DECRYPT | **Yes** (actual decryption in QSEE) |
+| 29 | INITIALIZE_DECRYPT_UNIT | **Yes** |
+
+**Practical attack chain to reach Widevine trustlet:**
+```bash
+# Step 1: Get unique ID
+service call drm.drmManager 1
+
+# Step 2: Add client session
+service call drm.drmManager 3 i32 <uniqueId>
+
+# Step 3: Open decrypt session with Widevine (triggers QSEE load)
+service call drm.drmManager 25 i32 <uniqueId> s16 "/path/to/content" s16 "video/mp4"
+
+# Step 4: Fuzz DECRYPT and ACQUIRE_DRM_INFO with malformed parcels
+# These reach the Widevine trustlet's command parsing in QSEE
+```
+
+**Confirm QSEE is reached by watching dmesg during each call:**
 
 ```bash
 # In terminal 1: watch dmesg
 adb shell "dmesg -w" > /tmp/dmesg_drm_probe.log &
 
 # In terminal 2: probe transactions
-adb shell "service call drm.drmManager 3"
+adb shell "service call drm.drmManager 25 i32 1 s16 'test' s16 'video/mp4'"
 # Check if new QSEE/widevine/OEMCrypto messages appear in dmesg
 ```
+
+**Reference:** [Wideshears: Breaking Widevine on QTEE (Black Hat Asia 2021)](https://i.blackhat.com/asia-21/Thursday-Handouts/as-21-Zhao-Wideshears-Investigating-And-Breaking-Widevine-On-QTEE-wp.pdf)
 
 ### Step 2.2: FIDO Crypto Daemon interface mapping
 
@@ -183,16 +206,20 @@ adb shell "find /system -name '*security*shim*' 2>/dev/null"
 
 ### Step 2.4: Gatekeeper interface mapping
 
-IGateKeeperService has a small, known interface:
+IGateKeeperService has a small, confirmed interface:
 
 ```bash
-# Known transaction codes for GateKeeperService:
-# 1 = ENROLL (takes uid, current_password_handle, current_password, desired_password)
-# 2 = VERIFY (takes uid, challenge, enrolled_password_handle, provided_password)
+# Confirmed transaction codes for GateKeeperService:
+# 1 = ENROLL (userId, currentPasswordHandle, currentPassword, desiredPassword)
+# 2 = VERIFY (userId, enrolledPasswordHandle, providedPassword)
+# 3 = VERIFY_CHALLENGE (challenge, userId, enrolledPasswordHandle, providedPassword)
+# 4 = GET_SECURE_USER_ID (userId) → int64
+# 5 = CLEAR_SECURE_USER_ID (userId)
 
-# Test basic verify call (should return error, not crash)
+# Test each operation (should return error, not crash)
 adb shell "service call android.service.gatekeeper.IGateKeeperService 1 i32 0 i32 0 i32 0 i32 0"
 adb shell "service call android.service.gatekeeper.IGateKeeperService 2 i32 0 i64 0 i32 0 i32 0"
+adb shell "service call android.service.gatekeeper.IGateKeeperService 4 i32 0"
 ```
 
 ### Step 2.5: Keystore interface mapping
@@ -221,7 +248,16 @@ done 2>&1 | tee /data/local/tmp/keystore_transactions.txt
 
 ### Step 3.1: Build a binder fuzzer
 
-Write a C program that can send arbitrary Parcel data to binder services. This gives us more control than `service call`:
+**Option A: libdevbinder** (recommended) — C library that abstracts binder ioctls into a socket-like API, supports arm64 cross-compilation: https://github.com/androidoffsec/libdevbinder
+
+**Option B: Custom fuzzer.** Write a C program using raw `/dev/binder` ioctls.
+
+**`service call` syntax reference** for shell-based fuzzing:
+```
+service call <SERVICE> <CODE> [i32 N | i64 N | f N | d N | s16 STR | null | fd F]
+```
+
+Write a program that can send arbitrary Parcel data to binder services. This gives us more control than `service call`:
 
 ```c
 // binder_fuzz.c — targeted binder transaction fuzzer
@@ -570,6 +606,22 @@ START
 | Ghidra | Trustlet reverse engineering | Need to confirm |
 | ADB | Device communication | Yes |
 | Python 3 | ELF reconstruction, scripting | Yes |
+| libdevbinder | Binder ioctl abstraction for C fuzzer | [github.com/androidoffsec/libdevbinder](https://github.com/androidoffsec/libdevbinder) |
+
+---
+
+## References
+
+- [QSEE Privilege Escalation CVE-2015-6639 (Bits Please)](http://bits-please.blogspot.com/2016/05/qsee-privilege-escalation-vulnerability.html)
+- [TrustZone Kernel CVE-2016-2431 (Bits Please)](http://bits-please.blogspot.com/2016/06/trustzone-kernel-privilege-escalation.html)
+- [Exploring Qualcomm's Secure Execution Environment (Bits Please)](http://bits-please.blogspot.com/2016/04/exploring-qualcomms-secure-execution.html)
+- [Extracting Qualcomm's KeyMaster Keys (Bits Please)](http://bits-please.blogspot.com/2016/06/extracting-qualcomms-keymaster-keys.html)
+- [Wideshears: Breaking Widevine on QTEE (Black Hat Asia 2021)](https://i.blackhat.com/asia-21/Thursday-Handouts/as-21-Zhao-Wideshears-Investigating-And-Breaking-Widevine-On-QTEE-wp.pdf)
+- [Fuzzing Android System Services by Binder Call (Black Hat 2015)](https://blackhat.com/docs/us-15/materials/us-15-Gong-Fuzzing-Android-System-Services-By-Binder-Call-To-Escalate-Privilege.pdf)
+- [Binder Fuzzing (Android Offensive Security)](https://androidoffsec.withgoogle.com/posts/binder-fuzzing/)
+- [The Road to Qualcomm TrustZone Apps Fuzzing (Check Point)](https://research.checkpoint.com/2019/the-road-to-qualcomm-trustzone-apps-fuzzing/)
+- [FANS: Fuzzing Android Native System Services (USENIX 2020)](https://www.usenix.org/system/files/sec20-liu.pdf)
+- [Hunting for Android Privilege Escalation with a 32 Line Fuzzer (Trustwave)](https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/hunting-for-android-privilege-escalation-with-a-32-line-fuzzer/)
 
 ---
 

--- a/docs/plans/2026-03-08-trustzone-exploitation-plan.md
+++ b/docs/plans/2026-03-08-trustzone-exploitation-plan.md
@@ -1,0 +1,584 @@
+# TrustZone/QSEE Exploitation Plan — BlackBerry Priv
+
+**Device:** BlackBerry Priv STV100-3, Android 6.0.1, kernel 3.10.84, MSM8992
+**Patch level:** 2017-10-05 (kernel built March 2018)
+**Goal:** Achieve code execution in QSEE or TZ kernel to bypass all kernel-level protections and obtain root
+**Related:** [Issue #8](https://github.com/SaintPepsi/claude-on-blackberry/issues/8)
+
+---
+
+## Strategic Context
+
+Every kernel-level software exploit has failed (15 dead vectors). GRSEC/PAX with per-callsite slab isolation, SELinux enforcing, and hardened proc makes kernel exploitation from userspace extremely difficult.
+
+TrustZone operates at a **higher privilege level** than the kernel (EL3 vs EL1). If we can compromise QSEE, we can:
+- Disable hardware memory protections (XPUs)
+- Patch the kernel directly from secure world
+- Disable SELinux enforcement at the hardware level
+- Write arbitrary physical memory
+
+**The attack chain:**
+```
+Shell (uid=2000) → Binder IPC → System service → qseecomd → /dev/qseecom → QSEE trustlet
+                                                                                    ↓
+                                                                              BUG gives QSEE code exec
+                                                                                    ↓
+                                                                              Attack TZ kernel (EL3)
+                                                                                    ↓
+                                                                              Patch Normal World kernel → root
+```
+
+**What's confirmed reachable from shell via binder:**
+
+| Service | Binder Interface | Responds to shell? | QSEE path |
+|---------|-----------------|-------------------|-----------|
+| drm.drmManager | IDrmManagerService | Yes (`service call 1` returns data) | mediaserver → Widevine plugin → OEMCrypto → qseecomd |
+| fidocryptodaemon | Unknown | Yes (returns "Invalid argument") | daemon → QSEE FIDO trustlet |
+| gatekeeperd | IGateKeeperService | PID 642, reachable | HAL → qseecomd → gatekeeper trustlet |
+| keystore | IKeystoreService | Yes | HAL → qseecomd → keymaster trustlet |
+| trust_zone (BB) | ITrustZoneService | Yes | Unknown (proprietary) |
+
+---
+
+## Phase 1: CVE Variant Hunt (1-2 hours)
+
+**Goal:** Identify any QSEE/trustlet CVEs disclosed AFTER October 2017 that affect MSM8992 and are reachable through binder services.
+
+### Step 1.1: Enumerate target CVEs
+
+Research and check applicability of each:
+
+**QSEE Kernel CVEs (post-Oct 2017):**
+- CVE-2017-18153 — QSEE kernel use-after-free in mapping_list management. Patched Dec 2018. **Potentially unpatched.**
+- CVE-2017-11088 — QSEE kernel information disclosure. Patched Oct 2017 (borderline).
+- CVE-2018-11816 — QSEE kernel memory corruption in syscall handler. Patched Sept 2018. **Potentially unpatched.**
+- CVE-2018-11261 — QSEE kernel buffer overflow. Patched July 2018. **Potentially unpatched.**
+- CVE-2019-2252 — QSEE kernel integer overflow in memory allocation. Patched March 2019. **Potentially unpatched.**
+
+**Trustlet-specific CVEs (post-Oct 2017):**
+- CVE-2018-11264 — Widevine QSEE app buffer overflow (separate from 2015 CVE). Patched July 2018. **Potentially unpatched.**
+- CVE-2019-2244 — Keymaster trustlet buffer overflow. Patched Jan 2019. **Potentially unpatched.**
+- CVE-2019-2245 — Keymaster trustlet integer overflow. Patched Jan 2019. **Potentially unpatched.**
+
+**qseecomd CVEs (post-Oct 2017):**
+- CVE-2018-13886 — qseecomd heap buffer overflow. Patched Dec 2018. **Potentially unpatched.**
+- CVE-2018-11821 — qseecomd use-after-free. Patched Oct 2018. **Potentially unpatched.**
+
+### Step 1.2: Verify CVE applicability
+
+For each CVE identified above:
+
+```bash
+# Check if the vulnerable component exists on device
+adb shell "ls -la /system/vendor/lib/hw/keystore.msm8992.so"
+adb shell "ls -la /system/vendor/lib/hw/gatekeeper.msm8992.so"
+adb shell "ls -la /system/etc/firmware/widevine.*"
+adb shell "ls -la /system/bin/qseecomd"
+
+# Check build dates of components
+adb shell "stat /system/bin/qseecomd"
+adb shell "stat /system/vendor/lib/hw/keystore.msm8992.so"
+
+# Check QSEE version strings
+adb shell "strings /system/vendor/lib/hw/keystore.msm8992.so | grep -i version"
+adb shell "strings /system/vendor/lib/hw/gatekeeper.msm8992.so | grep -i version"
+```
+
+### Step 1.3: Deep-dive on most promising CVEs
+
+For each CVE that appears applicable:
+1. Find the original advisory/writeup
+2. Determine the exact vulnerable code path
+3. Determine if the code path is reachable from shell through binder
+4. Document the exploitation approach
+
+**Go/No-Go:** If any CVE is confirmed unpatched AND reachable from shell via binder, proceed directly to Phase 4 (exploit development). Otherwise, continue to Phase 2.
+
+---
+
+## Phase 2: Binder Interface Enumeration (1-2 hours)
+
+**Goal:** Map the complete binder interface of each TZ-connected service to understand what operations are available to us.
+
+### Step 2.1: DRM Manager interface mapping
+
+The DRM path is the best-documented route to Widevine. Android 6.0.1 IDrmManagerService has known transaction codes:
+
+```bash
+# Probe DRM service transaction codes 1-30
+for i in $(seq 1 30); do
+  echo "=== Transaction $i ==="
+  service call drm.drmManager $i
+done 2>&1 | tee /data/local/tmp/drm_transactions.txt
+```
+
+Key DRM transactions to identify:
+- `openDecryptSession` — opens a DRM session (path to plugin loading)
+- `initializeDecryptUnit` — initializes crypto (touches OEMCrypto)
+- `decrypt` — actual decryption (reaches QSEE)
+- `getConstraints` / `getDrmInfo` — metadata queries
+
+**What we're looking for:** Which transaction codes reach the Widevine plugin and trigger QSEE operations. We'll confirm by watching dmesg during each call:
+
+```bash
+# In terminal 1: watch dmesg
+adb shell "dmesg -w" > /tmp/dmesg_drm_probe.log &
+
+# In terminal 2: probe transactions
+adb shell "service call drm.drmManager 3"
+# Check if new QSEE/widevine/OEMCrypto messages appear in dmesg
+```
+
+### Step 2.2: FIDO Crypto Daemon interface mapping
+
+This is less documented. We need to discover the interface:
+
+```bash
+# Try to dump the service interface descriptor
+adb shell "service call com.qualcomm.qti.auth.fidocryptodaemon 0"
+
+# Probe transaction codes 1-50 (unknown interface)
+for i in $(seq 1 50); do
+  result=$(adb shell "service call com.qualcomm.qti.auth.fidocryptodaemon $i" 2>&1)
+  if [ "$result" != "" ] && ! echo "$result" | grep -q "Unknown"; then
+    echo "Transaction $i: $result"
+  fi
+done 2>&1 | tee /data/local/tmp/fido_transactions.txt
+```
+
+Also extract the daemon binary for analysis:
+```bash
+# Find the daemon binary
+adb shell "which fidocryptodaemon || find /system -name '*fidocrypto*' 2>/dev/null"
+
+# Pull it for local analysis
+adb pull /system/bin/fidocryptodaemon ./fidocryptodaemon
+# or wherever it lives
+
+# Extract interface information
+strings fidocryptodaemon | grep -i "transaction\|binder\|FIDO\|qsee\|auth"
+```
+
+### Step 2.3: BlackBerry TrustZone service mapping
+
+Completely undocumented. Systematic enumeration required:
+
+```bash
+# Get the interface descriptor (transaction 0 with INTERFACE_TRANSACTION)
+adb shell "service call com.blackberry.security.trustzone.ITrustZoneService 0"
+
+# Probe transaction codes 1-100
+for i in $(seq 1 100); do
+  result=$(adb shell "service call com.blackberry.security.trustzone.ITrustZoneService $i" 2>&1)
+  echo "TX $i: $result"
+done 2>&1 | tee /data/local/tmp/bb_tz_transactions.txt
+
+# Find the service binary
+adb shell "find /system -name '*trustzone*' -o -name '*TrustZone*' 2>/dev/null"
+adb shell "find /system -name '*security*shim*' 2>/dev/null"
+
+# Pull for local analysis
+# (path TBD based on find results)
+```
+
+### Step 2.4: Gatekeeper interface mapping
+
+IGateKeeperService has a small, known interface:
+
+```bash
+# Known transaction codes for GateKeeperService:
+# 1 = ENROLL (takes uid, current_password_handle, current_password, desired_password)
+# 2 = VERIFY (takes uid, challenge, enrolled_password_handle, provided_password)
+
+# Test basic verify call (should return error, not crash)
+adb shell "service call android.service.gatekeeper.IGateKeeperService 1 i32 0 i32 0 i32 0 i32 0"
+adb shell "service call android.service.gatekeeper.IGateKeeperService 2 i32 0 i64 0 i32 0 i32 0"
+```
+
+### Step 2.5: Keystore interface mapping
+
+IKeystoreService has many transaction codes (Android 6.0.1 keystore has ~30):
+
+```bash
+# Key operations that reach keymaster trustlet:
+# generate_key, import_key, sign, verify, encrypt, decrypt
+# These go through: keystore → keymaster HAL → qseecomd → keymaster trustlet
+
+# Probe accessible operations
+for i in $(seq 1 40); do
+  result=$(adb shell "service call android.security.keystore $i" 2>&1)
+  echo "TX $i: $result"
+done 2>&1 | tee /data/local/tmp/keystore_transactions.txt
+```
+
+**Go/No-Go:** If we identify transaction codes that reach QSEE (confirmed via dmesg output during probing), proceed to Phase 3 (fuzzing those specific transactions). If all transactions are filtered before reaching QSEE, reassess.
+
+---
+
+## Phase 3: Targeted Black-Box Fuzzing (2-4 hours)
+
+**Goal:** Send malformed data through the binder transactions identified in Phase 2 that reach QSEE, looking for crashes or unexpected behavior.
+
+### Step 3.1: Build a binder fuzzer
+
+Write a C program that can send arbitrary Parcel data to binder services. This gives us more control than `service call`:
+
+```c
+// binder_fuzz.c — targeted binder transaction fuzzer
+// Cross-compile: aarch64-linux-musl-gcc -static -O2 binder_fuzz.c -o binder_fuzz
+//
+// Features:
+// - Send arbitrary byte sequences as Parcel data
+// - Vary transaction codes
+// - Vary data sizes (especially near buffer boundaries: 0, 1, 4095, 4096, 8192, 65535)
+// - Log responses and monitor for crashes
+// - Rate-limited to avoid DoS-ing the device
+```
+
+Key fuzzing strategies per service:
+
+**DRM (Widevine path):**
+- Target `openDecryptSession` with malformed plugin names
+- Target `decrypt` with oversized buffers
+- Target crypto init with malformed key data
+- Specifically test buffer sizes at page boundaries (4096, 8192)
+
+**FIDO daemon:**
+- Send incrementally larger payloads to each active transaction code
+- Test with FIDO-protocol-like structures (CBOR-encoded data with malformed lengths)
+- Focus on authentication request/response handlers
+
+**BB TrustZone service:**
+- Brute-force transaction codes with various payload sizes
+- Focus on any transaction that doesn't immediately return error
+- Test with BlackBerry-specific data structures if found during RE
+
+### Step 3.2: Crash monitoring setup
+
+```bash
+# Terminal 1: Continuous dmesg monitoring (save to file)
+adb shell "dmesg -w" | tee /tmp/fuzz_dmesg.log &
+
+# Terminal 2: Watch for process crashes
+adb shell "while true; do
+  for proc in qseecomd mediaserver fidocryptodaemon gatekeeperd; do
+    pid=$(pidof \$proc 2>/dev/null)
+    if [ -z \"\$pid\" ]; then
+      echo \"$(date): \$proc CRASHED\"
+    fi
+  done
+  sleep 1
+done" | tee /tmp/fuzz_crashes.log &
+
+# Terminal 3: Check for tombstones after each fuzzing round
+adb shell "ls -lt /data/tombstones/ 2>/dev/null | head -5"
+```
+
+### Step 3.3: Interpret results
+
+For each crash found:
+1. **Collect dmesg output** around the crash timestamp
+2. **Check for kernel address leaks** in the crash trace (we know dmesg leaks these)
+3. **Identify the crash location** — is it in userspace (mediaserver/qseecomd) or kernel (QSEE driver)?
+4. **Determine reproducibility** — can we trigger the same crash consistently?
+5. **Classify the bug type** — null deref (usually not exploitable), heap corruption (promising), stack overflow (promising), use-after-free (very promising)
+
+**Go/No-Go:**
+- Reproducible crash in qseecomd or a trustlet-facing component → proceed to Phase 5 (exploit development)
+- Crashes only in userspace (mediaserver) without reaching QSEE → analyze if the crash is in the QSEE communication path
+- No crashes → proceed to Phase 4 (binary RE)
+
+---
+
+## Phase 4: Trustlet Binary Extraction and RE (3-6 hours)
+
+**Goal:** Reverse engineer trustlet binaries to find vulnerabilities through static analysis.
+
+### Step 4.1: Extract all trustlet binaries
+
+```bash
+# Pull all firmware segments
+adb pull /system/etc/firmware/ ./firmware/
+
+# Key trustlets to analyze:
+# widevine.{mdt,b00,b01,b02,b03} — Widevine DRM (181KB code segment)
+# keymaster related files
+# gatekeeper related files
+# Any FIDO-related trustlet
+
+# List all .mdt files (trustlet metadata)
+adb shell "find /system/etc/firmware /vendor/firmware -name '*.mdt' 2>/dev/null"
+
+# Also check for additional trustlet locations
+adb shell "find /system /vendor -name '*.b02' 2>/dev/null"
+```
+
+### Step 4.2: Prepare trustlets for Ghidra
+
+Trustlet binaries are ELF segments. The `.b02` file is typically the code/data segment:
+
+```bash
+# For Widevine:
+# widevine.mdt — metadata/header (contains ELF headers + hash segments)
+# widevine.b00 — hash segment
+# widevine.b01 — cert chain
+# widevine.b02 — CODE segment (this is what we reverse)
+# widevine.b03 — data/bss
+
+# Option A: Load b02 directly as raw ARM 32-bit binary
+# In Ghidra: File → Import → widevine.b02
+# Language: ARM:LE:32:v7 (QSEE trustlets are 32-bit ARM even on 64-bit SoC)
+# Base address: Try 0x0 initially, adjust if references don't resolve
+
+# Option B: Reconstruct full ELF from mdt + segments
+# The mdt file contains the ELF header and program headers
+# Tools: https://github.com/pxcs/QSEE-ELF-reconstructor (or manual reconstruction)
+python3 -c "
+import struct
+# Read mdt for ELF header
+with open('firmware/widevine.mdt', 'rb') as f:
+    elf = f.read()
+# Read code segment
+with open('firmware/widevine.b02', 'rb') as f:
+    code = f.read()
+print(f'ELF header: {elf[:4]}')
+print(f'Code size: {len(code)} bytes')
+print(f'Architecture: {elf[18:20].hex()}')
+"
+```
+
+### Step 4.3: Identify attack surface in Widevine trustlet
+
+In Ghidra, focus on:
+
+1. **SMC/SVC handler entry points** — where Normal World requests enter the trustlet
+2. **PRDiag handler** — the function targeted by CVE-2015-6639 (check if patched)
+3. **OEMCrypto command handlers** — decrypt, key derivation, signature operations
+4. **Buffer handling** — look for `memcpy` without bounds checking, integer overflows in size calculations
+5. **String processing** — any place that processes strings from Normal World input
+
+Key patterns to search for in disassembly:
+```
+# Dangerous function calls:
+memcpy, memmove, strcpy, strncpy, sprintf
+# Size calculations:
+ADD followed by LDR/STR without overflow check
+# Trust boundary crossings:
+reads from shared memory regions (ION buffers)
+```
+
+### Step 4.4: Identify attack surface in other trustlets
+
+Repeat Step 4.3 for:
+- Keymaster trustlet (if extractable)
+- Gatekeeper trustlet (if extractable)
+- FIDO trustlet (if extractable)
+- Any BlackBerry-specific trustlets
+
+### Step 4.5: Cross-reference with fuzzing results
+
+If Phase 3 produced crashes:
+- Locate the crashing function in the disassembly
+- Understand the root cause
+- Determine if it's exploitable
+- Design the exploitation strategy
+
+**Go/No-Go:** If a vulnerability is found (either through RE or through crash analysis), proceed to Phase 5. If all trustlets appear clean, this approach is exhausted — document findings and reassess overall strategy.
+
+---
+
+## Phase 5: Exploit Development (4-8 hours)
+
+**Goal:** Turn a confirmed vulnerability into QSEE code execution, then pivot to kernel patching.
+
+### Step 5.1: Understand the vulnerability
+
+- Document the exact bug: buffer overflow, use-after-free, integer overflow, etc.
+- Determine the data path: how does our input from binder reach the vulnerable code?
+- Identify constraints: what data transformations happen along the way?
+- Map the memory layout: where does our controlled data land relative to the vulnerability?
+
+### Step 5.2: Build the trigger
+
+Write a C program that:
+1. Opens the appropriate binder service
+2. Sends the correct transaction to reach the vulnerable trustlet function
+3. Includes the payload that triggers the bug
+4. Demonstrates the crash is controllable (e.g., can control PC register)
+
+```bash
+# Cross-compile the trigger
+aarch64-linux-musl-gcc -static -O2 qsee_trigger.c -o qsee_trigger
+adb push qsee_trigger /data/local/tmp/
+adb shell "/data/local/tmp/qsee_trigger"
+```
+
+### Step 5.3: Develop the payload
+
+QSEE exploitation is different from kernel exploitation:
+- QSEE has its own memory space, separate from Normal World
+- Trustlets run as 32-bit ARM (even on 64-bit SoC)
+- No ASLR in QSEE on this era of Qualcomm chips
+- QSEE has access to Secure World physical memory
+
+**If we get QSEE app-level code execution:**
+- We need to escalate to TZ kernel (EL3)
+- CVE-2016-2431 style: abuse QSEE syscalls to corrupt TZ kernel memory
+- Alternative: use QSEE's direct physical memory access to patch Normal World kernel
+
+**Kernel patching from QSEE/EL3:**
+```
+# Target addresses (known, no KASLR):
+commit_creds:        0xffffffc00024a840
+prepare_kernel_cred: 0xffffffc00024ab74
+selinux_enforcing:   0xffffffc001649178
+init_cred:           0xffffffc00162d688
+
+# Strategy:
+# 1. From QSEE/EL3, write 0x00000000 to selinux_enforcing (disable SELinux)
+# 2. Write shellcode to a known kernel address
+# 3. Trigger the shellcode from Normal World (e.g., via a hooked syscall)
+# 4. Shellcode calls commit_creds(prepare_kernel_cred(0)) for current process
+# 5. Shell is now root with SELinux disabled
+```
+
+### Step 5.4: Test and verify
+
+```bash
+# After exploit runs:
+adb shell "id"
+# Expected: uid=0(root) gid=0(root)
+
+# Verify SELinux status:
+adb shell "getenforce"
+# Expected: Permissive (or Disabled)
+
+# If successful, proceed to persistence (Issue #23 in OUTSTANDING-TASKS.md)
+```
+
+---
+
+## Phase 6: Crash Dump Analysis (Ongoing, parallel to all phases)
+
+**Goal:** Mine dmesg continuously for useful information.
+
+### Step 6.1: Fresh address leak harvest
+
+```bash
+# Trigger controlled crashes and harvest addresses
+adb shell "dmesg | grep -E 'ffffffc0|qsee|trustzone|scm|tzbsp'" > /tmp/tz_dmesg.txt
+
+# Look for QSEE-specific kernel messages
+adb shell "dmesg | grep -iE 'qseecom|scm_call|tz_log'" > /tmp/qsee_kernel_msgs.txt
+
+# Check TZ log buffer (sometimes readable)
+adb shell "cat /d/tzdbg/log 2>/dev/null || echo 'not accessible'"
+adb shell "cat /d/tzdbg/qsee_log 2>/dev/null || echo 'not accessible'"
+```
+
+### Step 6.2: debugfs QSEE information
+
+We know debugfs is broadly readable:
+
+```bash
+# Check for QSEE debug info
+adb shell "ls /sys/kernel/debug/tzdbg/ 2>/dev/null"
+adb shell "cat /sys/kernel/debug/tzdbg/log 2>/dev/null"
+adb shell "cat /sys/kernel/debug/tzdbg/qsee_log 2>/dev/null"
+adb shell "cat /sys/kernel/debug/tzdbg/display 2>/dev/null"
+
+# ION debug info (QSEE heap layout)
+adb shell "cat /sys/kernel/debug/ion/heaps/qsecom 2>/dev/null"
+```
+
+---
+
+## Parallelization
+
+| Phase | Can run in parallel with | Dependencies |
+|-------|-------------------------|-------------|
+| Phase 1 (CVE hunt) | Phase 6 (crash dumps) | None |
+| Phase 2 (binder enum) | Phase 1, Phase 6 | None |
+| Phase 3 (fuzzing) | Phase 4 (RE) partially | Depends on Phase 2 for target transactions |
+| Phase 4 (RE) | Phase 3 | Depends on Phase 4.1 (extraction) only |
+| Phase 5 (exploit dev) | Nothing | Depends on confirmed vulnerability from Phase 3 or 4 |
+| Phase 6 (crash dumps) | Everything | None |
+
+**Recommended parallel execution:**
+- Session A: Phase 1 + Phase 2 + Phase 6 (all recon, no modifications)
+- Session B: Phase 3 (fuzzing) + Phase 4 (RE) — fuzzing on device while RE on laptop
+- Session C: Phase 5 (exploit development) — only if vulnerability confirmed
+
+---
+
+## Time Estimates
+
+| Phase | Estimated Time | Confidence |
+|-------|---------------|------------|
+| Phase 1: CVE variant hunt | 1-2 hours | High (research only) |
+| Phase 2: Binder enumeration | 1-2 hours | High (systematic probing) |
+| Phase 3: Black-box fuzzing | 2-4 hours | Medium (depends on crash findings) |
+| Phase 4: Trustlet RE | 3-6 hours | Low (depends on binary complexity) |
+| Phase 5: Exploit development | 4-8 hours | Low (depends on vulnerability found) |
+| Phase 6: Crash dump analysis | Ongoing | N/A (parallel) |
+| **Total (sequential)** | **11-22 hours** | |
+| **Total (parallelized)** | **7-14 hours** | |
+
+---
+
+## Decision Tree
+
+```
+START
+  │
+  ├─ Phase 1: Any unpatched QSEE CVE found?
+  │   ├─ YES → Is it reachable from shell via binder?
+  │   │   ├─ YES → Jump to Phase 5 (exploit known CVE)
+  │   │   └─ NO → Continue to Phase 2
+  │   └─ NO → Continue to Phase 2
+  │
+  ├─ Phase 2: Any binder transactions reach QSEE?
+  │   ├─ YES → Continue to Phase 3 (fuzz those transactions)
+  │   └─ NO → All binder paths filtered before QSEE
+  │       └─ DEAD END for this approach
+  │
+  ├─ Phase 3: Any crashes from fuzzing?
+  │   ├─ YES, in QSEE/qseecomd → Phase 5 (exploit the crash)
+  │   ├─ YES, in userspace only → Analyze crash location
+  │   │   ├─ In QSEE communication path → Phase 5
+  │   │   └─ Not in QSEE path → Continue to Phase 4
+  │   └─ NO crashes → Continue to Phase 4
+  │
+  ├─ Phase 4: Vulnerability found through RE?
+  │   ├─ YES → Phase 5 (exploit it)
+  │   └─ NO → TrustZone approach exhausted
+  │       └─ Pivot to hardware approaches (eMMC ISP, Issue #5)
+  │
+  └─ Phase 5: Exploit successful?
+      ├─ YES → ROOT ACHIEVED (Issues #22, #23)
+      └─ NO → Re-analyze, iterate, or pivot to hardware
+```
+
+---
+
+## Tools Required
+
+| Tool | Purpose | Have it? |
+|------|---------|---------|
+| aarch64-linux-musl-gcc | Cross-compile ARM64 binaries | Yes |
+| arm-linux-musleabihf-gcc | Cross-compile ARM32 binaries (for trustlet-matching payloads) | Yes |
+| Ghidra | Trustlet reverse engineering | Need to confirm |
+| ADB | Device communication | Yes |
+| Python 3 | ELF reconstruction, scripting | Yes |
+
+---
+
+## Risk Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Fuzzing crashes device permanently | High | Save state first. Start with read-only probes. Use rate limiting. |
+| qseecomd crash puts device in bad state | Medium | Reboot recovers. Test with non-destructive probes first. |
+| SELinux blocks binder calls we think work | Medium | Verify each call actually reaches QSEE via dmesg correlation. |
+| All trustlets are clean/patched | High | Accept and pivot to hardware approaches (eMMC ISP). |
+| Widevine trustlet uses obfuscation | Medium | BB-signed, not commercial obfuscation. Likely clean ARM code. |

--- a/docs/plans/2026-03-08-trustzone-exploitation-plan.md
+++ b/docs/plans/2026-03-08-trustzone-exploitation-plan.md
@@ -46,23 +46,42 @@ Shell (uid=2000) → Binder IPC → System service → qseecomd → /dev/qseecom
 
 ### Step 1.1: Enumerate target CVEs
 
-Research and check applicability of each:
+**CRITICAL CONSTRAINT:** Most QSEE CVEs require direct `/dev/qseecom` access, which is SELinux-blocked for shell. Only CVEs reachable through binder services (DRM, keystore, gatekeeper, FIDO) are exploitable from our position. The table below marks reachability.
 
-**QSEE Kernel CVEs (post-Oct 2017):**
-- CVE-2017-18153 — QSEE kernel use-after-free in mapping_list management. Patched Dec 2018. **Potentially unpatched.**
-- CVE-2017-11088 — QSEE kernel information disclosure. Patched Oct 2017 (borderline).
-- CVE-2018-11816 — QSEE kernel memory corruption in syscall handler. Patched Sept 2018. **Potentially unpatched.**
-- CVE-2018-11261 — QSEE kernel buffer overflow. Patched July 2018. **Potentially unpatched.**
-- CVE-2019-2252 — QSEE kernel integer overflow in memory allocation. Patched March 2019. **Potentially unpatched.**
+**Tier 1: Reachable via binder (highest priority)**
 
-**Trustlet-specific CVEs (post-Oct 2017):**
-- CVE-2018-11264 — Widevine QSEE app buffer overflow (separate from 2015 CVE). Patched July 2018. **Potentially unpatched.**
-- CVE-2019-2244 — Keymaster trustlet buffer overflow. Patched Jan 2019. **Potentially unpatched.**
-- CVE-2019-2245 — Keymaster trustlet integer overflow. Patched Jan 2019. **Potentially unpatched.**
+| CVE | Target | Patched | Type | Binder path |
+|-----|--------|---------|------|-------------|
+| CVE-2018-5868 | Widevine trustlet | ~Oct 2018 | Buffer overflow, no input size checking | DRM binder → mediaserver → Widevine plugin |
+| CVE-2019-2244 | Keymaster trustlet | Jan 2019 | Buffer overflow | keystore binder → keymaster HAL |
+| CVE-2019-2245 | Keymaster trustlet | Jan 2019 | Integer overflow | keystore binder → keymaster HAL |
+| CVE-2019-10574 | kmota (key storage) trustlet | ~Nov 2019 | Buffer over-read | Possibly via keystore |
 
-**qseecomd CVEs (post-Oct 2017):**
-- CVE-2018-13886 — qseecomd heap buffer overflow. Patched Dec 2018. **Potentially unpatched.**
-- CVE-2018-11821 — qseecomd use-after-free. Patched Oct 2018. **Potentially unpatched.**
+**Tier 2: Require qseecom access (need intermediate exploit first)**
+
+| CVE | Target | Patched | Type | Notes |
+|-----|--------|---------|------|-------|
+| CVE-2019-14040 | qseecom driver | Feb 2020 | UAF in ION buffer handling | **Public PoC exists** (Zimperium). Kernel root from qseecom. |
+| CVE-2019-14041 | qseecom driver | Feb 2020 | Race condition in `__qseecom_update_cmd_buf` | **Public PoC on GitHub** (tamirzb/CVE-2019-14041) |
+| CVE-2017-18316 | QSEE kernel "Ontario" driver | ~Dec 2018 | EoP from compromised trustlet to QSEE kernel | Chain: trustlet exploit → this → full TZ control |
+| CVE-2018-11950 | QSEE kernel TA loading | ~Dec 2018 | Load unapproved TrustZone apps | May be narrower scope (SD845+) |
+
+**Tier 3: Design flaws (no patch deployed)**
+
+| Attack | Target | Status | Notes |
+|--------|--------|--------|-------|
+| Trustlet Downgrade (RAID 2017) | QSEE TA loading | **No universal fix** | Trustlets have version=0, no rollback protection. Can re-load old vulnerable Widevine to re-enable CVE-2015-6639. Requires root + qseecom. [arxiv.org/pdf/1707.05082](https://arxiv.org/pdf/1707.05082) |
+
+**Tier 4: Previously assessed (confirmed dead)**
+
+| CVE | Why dead |
+|-----|----------|
+| CVE-2015-6639 | Widevine binary dated March 2018, likely patched |
+| CVE-2016-2431 | Requires CVE-2015-6639 first, which is likely patched |
+| CVE-2018-11976 | Requires root + custom kernel module (catch-22) |
+| CVE-2017-0620 | Patched April 2017, before device patch level |
+
+**Key insight:** CVE-2018-5868 (Widevine buffer overflow) is the most promising lead. It's a DIFFERENT vulnerability from the 2015 CVE, patched ~Oct 2018 (13 months after our device's patch level), and the DRM binder path to Widevine is confirmed reachable from shell.
 
 ### Step 1.2: Verify CVE applicability
 


### PR DESCRIPTION
## Summary

- Structured 6-phase plan for TrustZone exploitation on the BB Priv
- Covers: CVE variant hunting → binder enumeration → black-box fuzzing → trustlet RE → exploit development
- Includes concrete ADB commands, decision tree, parallelization strategy, and go/no-go criteria at each phase
- Estimated 7-14 hours parallelized across sessions

## Phases

1. **CVE Variant Hunt** (1-2h) — 10 post-Oct-2017 QSEE CVEs identified to check
2. **Binder Interface Enumeration** (1-2h) — Map DRM, FIDO, BB TrustZone, gatekeeper, keystore
3. **Targeted Fuzzing** (2-4h) — Fuzz binder transactions that reach QSEE
4. **Trustlet Binary RE** (3-6h) — Ghidra analysis of Widevine and other trustlets
5. **Exploit Development** (4-8h) — If vulnerability found
6. **Crash Dump Analysis** (ongoing) — Parallel dmesg mining

## Related

- Closes planning portion of #8
- Builds on Session 24 findings (PR #12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)